### PR TITLE
Added History Back to Talib Indicators 

### DIFF
--- a/tensortrade/features/feature_pipeline.py
+++ b/tensortrade/features/feature_pipeline.py
@@ -1,16 +1,3 @@
-# Copyright 2019 The TensorTrade Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 import pandas as pd
 import numpy as np
@@ -42,10 +29,23 @@ class FeaturePipeline(Component):
     def steps(self, steps: List[FeatureTransformer]):
         self._steps = steps
 
+    @property
+    def observation_columns(self) -> pd.DataFrame:
+        ret = [] 
+        for transformer in self._steps:
+            ret+= transformer.observation_columns()
+        return ret 
+        
     def reset(self):
         """Reset all transformers within the feature pipeline."""
         for transformer in self._steps:
             transformer.reset()
+
+    def transform_spaces(self, low, high):
+        """Transforms bounding space same as observations to reflect the post processed data""" 
+        for transformer in self._steps: 
+            low, high = transformer.transform_spaces(low, high)
+        return low,high 
 
     def _transform(self, observations: pd.DataFrame) -> pd.DataFrame:
         """Utility method for transforming observations via a list of `FeatureTransformer` objects."""

--- a/tensortrade/features/indicators/talib_indicator.py
+++ b/tensortrade/features/indicators/talib_indicator.py
@@ -25,32 +25,57 @@ class TAlibIndicator(FeatureTransformer):
 
     def __init__(self, indicators: List[str], lows: Union[List[float], List[int]] = None, highs: Union[List[float], List[int]] = None, **kwargs):
         self._indicator_names = [indicator[0].upper() for indicator in indicators]
+        self._indicators = [getattr(talib, name.split('-')[0]) for name in self._indicator_names]
         self._indicator_args = {indicator[0]:indicator[1]['args'] for indicator in indicators}
         self._indicator_params = {indicator[0]: indicator[1]['params'] for indicator in indicators}
-        self._indicators = [getattr(talib, name.split('-')[0]) for name in self._indicator_names]
+
+        #columns 
+        self._ohlcv_cols = ['date','open', 'high', 'low', 'close', 'volume', 'volumeto']
+        self._other_cols = [indicator_name.upper() for indicator_name in self._indicator_names if indicator_name != "BBANDS"]
+        self._bband_cols = ["bb_upper", "bb_middle", "bb_lower"]
+
+    def init_history(self):
+        self._history = pd.DataFrame(columns = self._ohlcv_cols + self._other_cols + self._bband_cols)
+
+    def observation_columns(self):
+        return self._other_cols+self._bband_cols
+
+    def transform_spaces(self, low, high):
+        new_low, new_high = low.copy(), high.copy()
+        return new_low, new_high
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        #concat new observations to the history 
+        window_size = len(X)
+        self._history = pd.concat([self._history, X], ignore_index=False)
+
         for idx, indicator in enumerate(self._indicators):
             indicator_name = self._indicator_names[idx]
-            indicator_args = [X[arg].values for arg in self._indicator_args[indicator_name]]
+            indicator_args = [self._history[arg].values for arg in self._indicator_args[indicator_name]]
             indicator_params = self._indicator_params[indicator_name]
 
             if indicator_name == 'BBANDS':
                 upper, middle, lower = indicator(*indicator_args,**indicator_params)
 
-                X["bb_upper"] = upper
-                X["bb_middle"] = middle
-                X["bb_lower"] = lower
+                self._history["bb_upper"] = upper
+                self._history["bb_middle"] = middle
+                self._history["bb_lower"] = lower
             else:
                 try:
                     value = indicator(*indicator_args,**indicator_params)
 
                     if type(value) == tuple:
-                        X[indicator_name] = value[0][0]
+                        self._history[indicator_name] = value[0][0]
                     else:
-                        X[indicator_name] = value
+                        self._history[indicator_name] = value
 
                 except:
-                    X[indicator_name] = indicator(*indicator_args,**indicator_params)[0]
+                    self._history[indicator_name] = indicator(*indicator_args,**indicator_params)[0]
 
-        return X
+        #return window size of observations 
+        return self._history.tail(window_size)
+    
+    def reset(self):
+        self.init_history()
+        super().reset()
+

--- a/tensortrade/features/scalers/min_max_normalizer.py
+++ b/tensortrade/features/scalers/min_max_normalizer.py
@@ -44,6 +44,18 @@ class MinMaxNormalizer(FeatureTransformer):
         self._input_max = input_max
         self._feature_min = feature_min
         self._feature_max = feature_max
+    
+    def transform_spaces(self, low, high):
+        #transforms observation space bounds to feature_min and max
+        new_low, new_high = low.copy(), high.copy()
+        scale = (self._feature_max - self._feature_min) + self._feature_min
+
+
+        new_low = (new_low-low) /(high-low) * scale
+        new_high = (new_high-low) /(high-low) * scale
+
+        return new_low, new_high
+
 
         if feature_min >= feature_max:
             raise ValueError("feature_min must be less than feature_max")
@@ -61,11 +73,10 @@ class MinMaxNormalizer(FeatureTransformer):
             if high - low == 0:
                 normalized_column = (1/len(X[column])) * scale
             else:
-                normalized_column = (X[column] - low) / (high - low) * scale
-
+                normalized_column = np.abs((X[column] - low) / (high - low) * scale)
             if not self._inplace:
                 column = '{}_minmax_{}_{}'.format(column, self._feature_min, self._feature_max)
-
+            
             args = {}
             args[column] = normalized_column + self._feature_min
 


### PR DESCRIPTION
History allows for the calculation of ta indicators on all the previously seen data rather than just the window size of observations passed in. The observation columns method has been included as a way to ensure the observation_space for the trading environment is correctly set. 