### PR TITLE
Update registry tests.

### DIFF
--- a/tests/tensortrade/unit/base/test_registry.py
+++ b/tests/tensortrade/unit/base/test_registry.py
@@ -4,13 +4,10 @@ import warnings
 import tensortrade.actions as actions
 import tensortrade.rewards as rewards
 
-from tensortrade.actions import DynamicOrders, ManagedRiskOrders
+from tensortrade.actions import SimpleOrders, ManagedRiskOrders
+from tensortrade.rewards import SimpleProfit, RiskAdjustedReturns
 
 warnings.filterwarnings("ignore")
-
-
-# def test_dynamic_actions():
-#     assert isinstance(actions.get('dynamic'), DynamicOrders)
 
 
 def test_simple_actions():
@@ -23,3 +20,7 @@ def test_managed_risk_actions():
 
 def test_simple_reward_scheme():
     assert isinstance(rewards.get('simple'), rewards.SimpleProfit)
+
+
+def test_risk_adjusted_reward_scheme():
+    assert isinstance(rewards.get('risk-adjusted'), rewards.RiskAdjustedReturns)

--- a/tests/tensortrade/unit/base/test_registry.py
+++ b/tests/tensortrade/unit/base/test_registry.py
@@ -9,8 +9,12 @@ from tensortrade.actions import DynamicOrders, ManagedRiskOrders
 warnings.filterwarnings("ignore")
 
 
-def test_dynamic_actions():
-    assert isinstance(actions.get('dynamic'), DynamicOrders)
+# def test_dynamic_actions():
+#     assert isinstance(actions.get('dynamic'), DynamicOrders)
+
+
+def test_simple_actions():
+    assert isinstance(actions.get('simple'), SimpleOrders)
 
 
 def test_managed_risk_actions():


### PR DESCRIPTION
Testing currently fail because DynamicOrders has been changed to SimpleOrders in the module but not in the corresponding test.