### PR TITLE
Fix episode counter not being incremented in dqn and a2c agents

### DIFF
--- a/tensortrade/agents/a2c_agent.py
+++ b/tensortrade/agents/a2c_agent.py
@@ -214,6 +214,8 @@ class A2CAgent(Agent):
             if save_path and (is_checkpoint or episode == n_episodes):
                 self.save(save_path, episode=episode)
 
+            episode += 1
+
             mean_reward = total_reward / steps_done
 
             return mean_reward

--- a/tensortrade/agents/dqn_agent.py
+++ b/tensortrade/agents/dqn_agent.py
@@ -168,6 +168,8 @@ class DQNAgent(Agent):
             if save_path and (is_checkpoint or episode == n_episodes - 1):
                 self.save(save_path, episode=episode)
 
+            episode += 1
+
             mean_reward = total_reward / steps_done
 
             return mean_reward


### PR DESCRIPTION
The outer while loop in the agent's train method was checking that the
current episode is not greater than the requested number of episodes but
the episode counter was not being incremented. This caused an infinite
loop if you did not specify number of steps.