### PR TITLE
Reshape returns Tensor in a2c_agent.py

### DIFF
--- a/tensortrade/agents/a2c_agent.py
+++ b/tensortrade/agents/a2c_agent.py
@@ -133,6 +133,7 @@ class A2CAgent(Agent):
         optimizer.apply_gradients(zip(gradients, self.critic_network.trainable_variables))
 
         with tf.GradientTape() as tape:
+            returns = tf.reshape(returns, [batch_size, 1])
             advantages = returns - values
 
             actions = tf.cast(actions, tf.int32)


### PR DESCRIPTION
In a2c_agent.py the returns tensor must be reshaped in order to calculate the avantages correctly. That way the error described in Issue #187 is resolved.