### PR TITLE
Fix reward being returned early after the first episode

### DIFF
--- a/tensortrade/agents/a2c_agent.py
+++ b/tensortrade/agents/a2c_agent.py
@@ -214,6 +214,6 @@ class A2CAgent(Agent):
             if save_path and (is_checkpoint or episode == n_episodes):
                 self.save(save_path, episode=episode)
 
-            mean_reward = total_reward / steps_done
+        mean_reward = total_reward / steps_done
 
-            return mean_reward
+        return mean_reward

--- a/tensortrade/agents/dqn_agent.py
+++ b/tensortrade/agents/dqn_agent.py
@@ -168,6 +168,6 @@ class DQNAgent(Agent):
             if save_path and (is_checkpoint or episode == n_episodes - 1):
                 self.save(save_path, episode=episode)
 
-            mean_reward = total_reward / steps_done
+        mean_reward = total_reward / steps_done
 
-            return mean_reward
+        return mean_reward


### PR DESCRIPTION
With commit https://github.com/tensortrade-org/tensortrade/commit/22b47fb67b95b08039fa335bed6053d97c7052f9, `train` now returns the mean reward but  the A2C and DQN agents return the reward prematurely. Only one episode runs. This change returns the mean reward after all the steps and episodes are completed.