### PR TITLE
Drop N frames to ensure that indicators are there

### DIFF
--- a/tensortrade/environments/trading_environment.py
+++ b/tensortrade/environments/trading_environment.py
@@ -102,6 +102,7 @@ class TradingEnvironment(gym.Env, TimeIndexed):
         self._observation_lows = kwargs.get('observation_lows', -np.iinfo(np.int32).max)
         self._observation_highs = kwargs.get('observation_highs', np.iinfo(np.int32).max)
         self._max_allowed_loss = kwargs.get('max_allowed_loss', 0.1)
+        self._drop_n_frames = kwargs.get('drop_n_frames', 0)
 
         if self._enable_logger:
             self.logger = logging.getLogger(kwargs.get('logger_name', __name__))
@@ -160,6 +161,7 @@ class TradingEnvironment(gym.Env, TimeIndexed):
         )
 
         self.feed.reset()
+        self._rewind()
 
     @property
     def portfolio(self) -> Portfolio:
@@ -272,6 +274,7 @@ class TradingEnvironment(gym.Env, TimeIndexed):
         self.episode_id = uuid.uuid4()
         self.clock.reset()
         self.feed.reset()
+        self._rewind()
         self.action_scheme.reset()
         self.reward_scheme.reset()
         self.portfolio.reset()
@@ -317,3 +320,7 @@ class TradingEnvironment(gym.Env, TimeIndexed):
         for renderer in self._renderers:
             if callable(hasattr(renderer, 'close')):
                 renderer.close()  # pylint: disable=no-member
+
+    def _rewind(self):
+        if self._drop_n_frames > 0:
+            for i in range(self._drop_n_frames): self.feed.next()


### PR DESCRIPTION
**Background**:
TT got the completely new `data feed` system to feed data into the environment. 
It's based on the `Node` object that encapsulates the way how data can be organized into a pipeline. 

One Node can feed data to another Node which can go to a third Node that will multiply a value by some other values, that come from different Nodes. The environment just calls `feed.next()` every step to get the next frame and doesn't know how and where the data come from. The interface above is too generic and flexible that allows easy implementing different data sources, transformations, Talib indicators, etc - the interface remains the same.

For example, I already implemented a `Delay` node which returns a value with a predefined delay (to get a price from an hour ago, or a day ago) and a `TAlib` node which calculates indicators based on an input stream.

One important implication of this system is that there is no _pre-transformation_ - you just select the source, define the pipeline and pass it to the environment - all transformations and aggregation will be executed as the environment calls `feed.next()`.

But there is a problem: some node transformations might require some amount of data to be collected before it can return a meaningful result. For example, the calculation `talib.SMA(close, timeperiod=30)` will require 30 elements before it can return the corresponding SMA. Before that, it will return N/A, which is an invalid value for a neural network. 

You can try to ignore it, and for training, it won't likely affect the model too much, but on a live exchange, your model might make incorrect actions based on incorrect SMA.

So here is my PR: the ability to tell the environment to ignore first N frames before it actually starts sending a data frame to an agent and executing actions.

