### PR TITLE
Fix for exploration/exploitation ratio

### DIFF
--- a/tensortrade/agents/dqn_agent.py
+++ b/tensortrade/agents/dqn_agent.py
@@ -135,6 +135,7 @@ class DQNAgent(Agent):
 
         memory = ReplayMemory(memory_capacity, transition_type=DQNTransition)
         episode = 0
+        total_steps_done = 0
         total_reward = 0
         stop_training = False
 
@@ -151,7 +152,7 @@ class DQNAgent(Agent):
             steps_done = 0
 
             while not done:
-                threshold = eps_end + (eps_start - eps_end) * np.exp(-steps_done / eps_decay_steps)
+                threshold = eps_end + (eps_start - eps_end) * np.exp(-total_steps_done / eps_decay_steps)
                 action = self.get_action(state, threshold=threshold)
                 next_state, reward, done, _ = self.env.step(action)
 
@@ -160,6 +161,7 @@ class DQNAgent(Agent):
                 state = next_state
                 total_reward += reward
                 steps_done += 1
+                total_steps_done +=1
 
                 if len(memory) < batch_size:
                     continue


### PR DESCRIPTION
At this moment exploration ratio gets reset on every episode during training. This makes agent choose random action  way too often.

---
This is how exploration ratio looks during training on current master:

![](https://i.imgur.com/UMeGJ3K.png)
---

This is how it should look (from Q Learning articles):

![](https://raw.githubusercontent.com/hollygrimm/blackjack-montecarlo/master/images/epsilon_values.png)
---

This is how it looks like with this bugfix:

![](https://i.imgur.com/F4M9KcZ.png)