### PR TITLE
Reset fix for rolling calculations

### DIFF
--- a/tensortrade/feed/api/float/window/ewm.py
+++ b/tensortrade/feed/api/float/window/ewm.py
@@ -95,6 +95,7 @@ class ExponentialWeightedMovingAverage(Stream[float]):
 
         self.avg = None
         self.old_wt = 1
+        super().reset()
 
 
 class ExponentialWeightedMovingCovariance(Stream[float]):
@@ -236,6 +237,7 @@ class ExponentialWeightedMovingCovariance(Stream[float]):
         self.sum_wt = 1
         self.sum_wt2 = 1
         self.old_wt = 1
+        super().reset()
 
 
 class EWM(Stream[List[float]]):
@@ -396,6 +398,10 @@ class EWM(Stream[List[float]]):
         """
         return self.var(bias).sqrt()
 
+    def reset(self) -> None:
+        self.history = []
+        self.weights = []
+        super().reset()
 
 @Float.register(["ewm"])
 def ewm(s: "Stream[float]",

--- a/tensortrade/feed/api/float/window/expanding.py
+++ b/tensortrade/feed/api/float/window/expanding.py
@@ -166,6 +166,10 @@ class Expanding(Stream[List[float]]):
         """
         return self.agg(np.max).astype("float")
 
+    def reset(self) -> None:
+        self.history = []
+        super().reset()
+
 
 @Float.register(["expanding"])
 def expanding(s: "Stream[float]", min_periods: int = 1) -> "Stream[List[float]]":

--- a/tensortrade/feed/api/float/window/rolling.py
+++ b/tensortrade/feed/api/float/window/rolling.py
@@ -35,6 +35,10 @@ class RollingNode(Stream[float]):
     def has_next(self) -> bool:
         return True
 
+    def reset(self) -> None:
+        self.n = 0
+        super().reset()
+
 
 class RollingCount(RollingNode):
     """A stream operator that counts the number of non-missing values in the
@@ -193,6 +197,12 @@ class Rolling(Stream[List[float]]):
         """
         func = np.nanmax if self.min_periods < self.window else np.max
         return self.agg(func).astype("float")
+
+    def reset(self) -> None:
+        self.n = 0
+        self.nan = 0
+        self.history = []
+        super().reset()
 
 
 @Float.register(["rolling"])


### PR DESCRIPTION
Added reset function overrides to RollingNode and Rolling classes
Observer feed reset missed clearing members of rolling classes causing stale data from feed initialization to remain resulting in incorrect values after environment reset.