### PR TITLE
BSH: check for balance prior to ordering

### DIFF
--- a/tensortrade/env/default/actions.py
+++ b/tensortrade/env/default/actions.py
@@ -155,8 +155,11 @@ class BSH(TensorTradeActionScheme):
         if abs(action - self.action) > 0:
             src = self.cash if self.action == 0 else self.asset
             tgt = self.asset if self.action == 0 else self.cash
-            if src.balance > 0:  # We need to check, regardless of the proposed order, if we have balance in 'src'
-                order = proportion_order(portfolio, src, tgt, 1.0)
+
+            if src.balance == 0:  # We need to check, regardless of the proposed order, if we have balance in 'src'
+                return []  # Otherwise just return an empty order list
+
+            order = proportion_order(portfolio, src, tgt, 1.0)
             self.action = action
 
         for listener in self.listeners:

--- a/tensortrade/env/default/actions.py
+++ b/tensortrade/env/default/actions.py
@@ -155,7 +155,8 @@ class BSH(TensorTradeActionScheme):
         if abs(action - self.action) > 0:
             src = self.cash if self.action == 0 else self.asset
             tgt = self.asset if self.action == 0 else self.cash
-            order = proportion_order(portfolio, src, tgt, 1.0)
+            if src.balance > 0:  # We need to check, regardless of the proposed order, if we have balance in 'src'
+                order = proportion_order(portfolio, src, tgt, 1.0)
             self.action = action
 
         for listener in self.listeners:


### PR DESCRIPTION
Without this, the agent tries to place an order even with 0 USD balance, using 100% of said balance. It tries to place an order of 0 USD which raises an error.