### PR TITLE
Fix max allowed loss

### DIFF
--- a/tensortrade/env/default/actions.py
+++ b/tensortrade/env/default/actions.py
@@ -1,4 +1,4 @@
-
+import logging
 from abc import abstractmethod
 from itertools import product
 from typing import Union, List, Any
@@ -91,6 +91,7 @@ class TensorTradeActionScheme(ActionScheme):
 
         for order in orders:
             if order:
+                logging.info('Step {}: {} {}'.format(order.step, order.side, order.quantity))
                 self.broker.submit(order)
 
         self.broker.update()

--- a/tensortrade/env/default/stoppers.py
+++ b/tensortrade/env/default/stoppers.py
@@ -9,13 +9,13 @@ class MaxLossStopper(Stopper):
     Parameters
     ----------
     max_allowed_loss : float
-        The maximum proportion of initial funds that is willing to
+        The maximum percentage of initial funds that is willing to
         be lost before stopping the episode.
 
     Attributes
     ----------
     max_allowed_loss : float
-        The maximum proportion of initial funds that is willing to
+        The maximum percentage of initial funds that is willing to
         be lost before stopping the episode.
 
     Notes
@@ -28,6 +28,6 @@ class MaxLossStopper(Stopper):
         self.max_allowed_loss = max_allowed_loss
 
     def stop(self, env: 'TradingEnv') -> bool:
-        c1 = env.action_scheme.portfolio.profit_loss < self.max_allowed_loss
+        c1 = env.action_scheme.portfolio.profit_loss > self.max_allowed_loss
         c2 = not env.observer.has_next()
         return c1 or c2

--- a/tensortrade/oms/exchanges/exchange.py
+++ b/tensortrade/oms/exchanges/exchange.py
@@ -37,8 +37,8 @@ class ExchangeOptions:
         The maximum price an exchange can have.
     is_live : bool, default False
         Whether live orders should be submitted to the exchange.
-    override_min_commission_precision : bool, default False
-        Sets the commission to the minimum value allowed by precision instead of canceling the order
+    allow_zero_commission_under_precision : bool, default False
+        When under precision, sets the commission to zero of canceling the order
     """
 
     def __init__(self,
@@ -48,14 +48,14 @@ class ExchangeOptions:
                  min_trade_price: float = 1e-8,
                  max_trade_price: float = 1e8,
                  is_live: bool = False,
-                 override_min_commission_precision: bool = False):
+                 allow_zero_commission_under_precision: bool = False):
         self.commission = commission
         self.min_trade_size = min_trade_size
         self.max_trade_size = max_trade_size
         self.min_trade_price = min_trade_price
         self.max_trade_price = max_trade_price
         self.is_live = is_live
-        self.override_min_commission_precision = override_min_commission_precision
+        self.allow_zero_commission_under_precision = allow_zero_commission_under_precision
 
 
 class Exchange(Component, TimedIdentifiable):

--- a/tensortrade/oms/exchanges/exchange.py
+++ b/tensortrade/oms/exchanges/exchange.py
@@ -37,6 +37,8 @@ class ExchangeOptions:
         The maximum price an exchange can have.
     is_live : bool, default False
         Whether live orders should be submitted to the exchange.
+    override_min_commission_precision : bool, default False
+        Sets the commission to the minimum value allowed by precision instead of canceling the order
     """
 
     def __init__(self,
@@ -45,13 +47,15 @@ class ExchangeOptions:
                  max_trade_size: float = 1e6,
                  min_trade_price: float = 1e-8,
                  max_trade_price: float = 1e8,
-                 is_live: bool = False):
+                 is_live: bool = False,
+                 override_min_commission_precision: bool = False):
         self.commission = commission
         self.min_trade_size = min_trade_size
         self.max_trade_size = max_trade_size
         self.min_trade_price = min_trade_price
         self.max_trade_price = max_trade_price
         self.is_live = is_live
+        self.override_min_commission_precision = override_min_commission_precision
 
 
 class Exchange(Component, TimedIdentifiable):

--- a/tensortrade/oms/exchanges/exchange.py
+++ b/tensortrade/oms/exchanges/exchange.py
@@ -37,8 +37,6 @@ class ExchangeOptions:
         The maximum price an exchange can have.
     is_live : bool, default False
         Whether live orders should be submitted to the exchange.
-    allow_zero_commission_under_precision : bool, default False
-        When under precision, sets the commission to zero of canceling the order
     """
 
     def __init__(self,
@@ -47,15 +45,13 @@ class ExchangeOptions:
                  max_trade_size: float = 1e6,
                  min_trade_price: float = 1e-8,
                  max_trade_price: float = 1e8,
-                 is_live: bool = False,
-                 allow_zero_commission_under_precision: bool = False):
+                 is_live: bool = False):
         self.commission = commission
         self.min_trade_size = min_trade_size
         self.max_trade_size = max_trade_size
         self.min_trade_price = min_trade_price
         self.max_trade_price = max_trade_price
         self.is_live = is_live
-        self.allow_zero_commission_under_precision = allow_zero_commission_under_precision
 
 
 class Exchange(Component, TimedIdentifiable):

--- a/tensortrade/oms/services/execution/simulated.py
+++ b/tensortrade/oms/services/execution/simulated.py
@@ -50,7 +50,7 @@ def execute_buy_order(order: 'Order',
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
         if options.allow_zero_commission_under_precision:
             logging.info("Commission is less than precision. Overriding zero commission value.")
-            commission.size = 0.0
+            commission = filled * 0
             quantity = filled - commission
         else:
             logging.warning("Commission is less than precision. Canceling order. "
@@ -120,7 +120,7 @@ def execute_sell_order(order: 'Order',
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
         if options.allow_zero_commission_under_precision:
             logging.info("Commission is less than precision. Overriding zero commission value.")
-            commission.size = 0.0
+            commission = filled * 0
             quantity = filled - commission
         else:
             logging.warning("Commission is less than precision. Canceling order. "

--- a/tensortrade/oms/services/execution/simulated.py
+++ b/tensortrade/oms/services/execution/simulated.py
@@ -48,15 +48,10 @@ def execute_buy_order(order: 'Order',
     quantity = filled - commission
 
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
-        if options.allow_zero_commission_under_precision:
-            logging.info("Commission is less than precision. Overriding zero commission value.")
-            commission = filled * 0
-            quantity = filled - commission
-        else:
-            logging.warning("Commission is less than precision. Canceling order. "
-                            "Consider setting allow_zero_commission_under_precision in the ExchangeOptions")
-            order.cancel("COMMISSION IS LESS THAN PRECISION.")
-            return None
+        logging.warning("Commission is less than instrument precision. Canceling order. "
+                        "Consider defining a custom instrument with a higher precision.")
+        order.cancel("COMMISSION IS LESS THAN PRECISION.")
+        return None
 
     transfer = Wallet.transfer(
         source=base_wallet,
@@ -118,15 +113,10 @@ def execute_sell_order(order: 'Order',
     quantity = filled - commission
 
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
-        if options.allow_zero_commission_under_precision:
-            logging.info("Commission is less than precision. Overriding zero commission value.")
-            commission = filled * 0
-            quantity = filled - commission
-        else:
-            logging.warning("Commission is less than precision. Canceling order. "
-                            "Consider setting allow_zero_commission_under_precision in the ExchangeOptions")
-            order.cancel("COMMISSION IS LESS THAN PRECISION.")
-            return None
+        logging.warning("Commission is less than instrument precision. Canceling order. "
+                        "Consider defining a custom instrument with a higher precision.")
+        order.cancel("COMMISSION IS LESS THAN PRECISION.")
+        return None
 
     # Transfer Funds from Quote Wallet to Base Wallet
     transfer = Wallet.transfer(

--- a/tensortrade/oms/services/execution/simulated.py
+++ b/tensortrade/oms/services/execution/simulated.py
@@ -48,13 +48,13 @@ def execute_buy_order(order: 'Order',
     quantity = filled - commission
 
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
-        if options.override_min_commission_precision:
-            logging.info("Commission is less than precision. Overriding with minimum commission value.")
-            commission.size = Decimal(10) ** -quantity.instrument.precision
+        if options.allow_zero_commission_under_precision:
+            logging.info("Commission is less than precision. Overriding zero commission value.")
+            commission.size = 0.0
             quantity = filled - commission
         else:
             logging.warning("Commission is less than precision. Canceling order. "
-                            "Consider setting override_min_commission_precision in the ExchangeOptions")
+                            "Consider setting allow_zero_commission_under_precision in the ExchangeOptions")
             order.cancel("COMMISSION IS LESS THAN PRECISION.")
             return None
 
@@ -118,13 +118,13 @@ def execute_sell_order(order: 'Order',
     quantity = filled - commission
 
     if commission.size < Decimal(10) ** -quantity.instrument.precision:
-        if options.override_min_commission_precision:
-            logging.info("Commission is less than precision. Overriding with minimum commission value.")
-            commission.size = Decimal(10) ** -quantity.instrument.precision
+        if options.allow_zero_commission_under_precision:
+            logging.info("Commission is less than precision. Overriding zero commission value.")
+            commission.size = 0.0
             quantity = filled - commission
         else:
             logging.warning("Commission is less than precision. Canceling order. "
-                            "Consider setting override_min_commission_precision in the ExchangeOptions")
+                            "Consider setting allow_zero_commission_under_precision in the ExchangeOptions")
             order.cancel("COMMISSION IS LESS THAN PRECISION.")
             return None
 


### PR DESCRIPTION
Fixes comparison operator, meaning that max_allowed_loss set to 0.01 will allow balance to drop to 99% of the original value (hence losing 1%) before stopping the run.