### PR TITLE
Fix max_allowed_loss operator and description

### DIFF
--- a/tensortrade/env/default/stoppers.py
+++ b/tensortrade/env/default/stoppers.py
@@ -9,13 +9,13 @@ class MaxLossStopper(Stopper):
     Parameters
     ----------
     max_allowed_loss : float
-        The maximum proportion of initial funds that is willing to
+        The maximum percentage of initial funds that is willing to
         be lost before stopping the episode.
 
     Attributes
     ----------
     max_allowed_loss : float
-        The maximum proportion of initial funds that is willing to
+        The maximum percentage of initial funds that is willing to
         be lost before stopping the episode.
 
     Notes
@@ -28,6 +28,6 @@ class MaxLossStopper(Stopper):
         self.max_allowed_loss = max_allowed_loss
 
     def stop(self, env: 'TradingEnv') -> bool:
-        c1 = env.action_scheme.portfolio.profit_loss < self.max_allowed_loss
+        c1 = env.action_scheme.portfolio.profit_loss > self.max_allowed_loss
         c2 = not env.observer.has_next()
         return c1 or c2


### PR DESCRIPTION
Fixes comparison operator, meaning that max_allowed_loss set to 0.01 will allow balance to drop to 99% of the original value (hence losing 1%) before stopping the run.