### PR TITLE
Fix Stream __new__ method causing TypeError in the documentation's code

### DIFF
--- a/tensortrade/feed/core/base.py
+++ b/tensortrade/feed/core/base.py
@@ -134,7 +134,7 @@ class Stream(Generic[T], Named, Observable):
 
     def __new__(cls, *args, **kwargs):
         dtype = kwargs.get("dtype")
-        instance = super().__new__(cls, *args, **kwargs)
+        instance = super().__new__(cls)
         if dtype in Stream._mixins.keys():
             mixin = Stream._mixins[dtype]
             instance = Stream.extend_instance(instance, mixin)


### PR DESCRIPTION
The usage of `super().__new__(cls, *args, **kwargs)` leads to an exception of the kind:
```python
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```

The easy fix is to avoid passing args and kwargs to the superclass' `__new__` method.

However i don't know this codebase. I was just trying to run my very first example using this library and got stuck at this error. The example manages to run with my change.
BUT i see that the `Stream` class inherits from multiple classes (`Generic[T], Named, Observable`), and MAYBE the problem raises from method resolution order?

Edit: i should mention I'm using Python 3.9.