### PR TITLE
Fix forever growing indentifiable object dict

### DIFF
--- a/tensortrade/core/base.py
+++ b/tensortrade/core/base.py
@@ -2,9 +2,6 @@
 
 Attributes
 ----------
-objects : Dict[str, Identifiable]
-    A dictionary responsible for mapping all identifiable objects created in
-    the project.
 global_clock : `Clock`
     A clock that provides a global reference for all objects that share a
     timeline.
@@ -17,7 +14,6 @@ from abc import ABCMeta
 from tensortrade.core.clock import Clock
 
 
-objects = {}
 global_clock = Clock()
 
 
@@ -36,7 +32,6 @@ class Identifiable(object, metaclass=ABCMeta):
         """
         if not hasattr(self, '_id'):
             self._id = str(uuid.uuid4())
-            objects[self._id] = self
         return self._id
 
     @id.setter
@@ -48,7 +43,6 @@ class Identifiable(object, metaclass=ABCMeta):
         identifier : str
             The identifier to set for the object.
         """
-        objects[identifier] = self
         self._id = identifier
 
 


### PR DESCRIPTION
When creating new order objects they seem to be stored in [tensortrade.core.base.objects](https://github.com/tensortrade-org/tensortrade/blob/master/tensortrade/core/base.py#L20) global dict.

This dict is not used anywhere as far as I can see. Besides that, the elements are never deleted from the dict causing the memory to fill up after a lot of episodes. Therefore the fix is to remove this dict.

One can use the following example code to test this. The dict size is printed every episode.

```
import random

import numpy as np
import pandas as pd
import tensortrade.core.base
from tensortrade.env import default
from tensortrade.env.default.actions import BSH
from tensortrade.feed import Stream, DataFeed
from tensortrade.oms.exchanges import Exchange
from tensortrade.oms.instruments import USD, BTC
from tensortrade.oms.services.execution.simulated import execute_order
from tensortrade.oms.wallets import Portfolio, Wallet

x = np.arange(0, 2 * np.pi, 2 * np.pi / 390)
y = 50 * np.sin(3 * x) + 100
data = pd.DataFrame(data=y, columns=["close"])

bitfinex = Exchange("bitfinex", service=execute_order)(
    Stream.source(list(data["close"]), dtype="float").rename("USD-BTC")
)
cash = Wallet(bitfinex, 10000 * USD)
asset = Wallet(bitfinex, 10 * BTC)

portfolio = Portfolio(USD, [cash, asset])
feed = DataFeed([Stream.source(list(data["close"]), dtype="float").rename("close")])

env = default.create(
    portfolio=portfolio,
    action_scheme=BSH(cash, asset),
    reward_scheme="risk-adjusted",
    feed=feed,
    renderer_feed=feed,
    renderer=default.renderers.EmptyRenderer(),
    window_size=20
)

for i in range(10):
    print(f'A. Object count {len(tensortrade.core.base.objects)}')
    obs = env.reset()
    done = False
    while not done:
        action = random.randint(0, env.action_space.n)
        next_state, reward, done, _ = env.step(action)


for i in range(10):
    print(f'B. Object count {len(tensortrade.core.base.objects)}')
    env.close()
    del env
    env = default.create(
        portfolio=portfolio,
        action_scheme="managed-risk",
        reward_scheme="risk-adjusted",
        feed=feed,
        renderer_feed=feed,
        renderer=default.renderers.PlotlyTradingChart(),
        window_size=20
    )
    obs = env.reset()
    done = False
    while not done:
        action = random.randint(0, env.action_space.n - 1)
        next_state, reward, done, _ = env.step(action)
```