### PR TITLE
Small modifications to allow multiple orders being executed in one environment step

### DIFF
--- a/tensortrade/oms/instruments/quantity.py
+++ b/tensortrade/oms/instruments/quantity.py
@@ -52,7 +52,10 @@ class Quantity:
 
     def __init__(self, instrument: 'Instrument', size: Union[Decimal, Number], path_id: str = None):
         if size < 0:
-            raise InvalidNegativeQuantity(size)
+            if abs(size) > Decimal(10)**(-instrument.precision):
+                raise InvalidNegativeQuantity(size)
+            else:
+                size = 0
 
         self.instrument = instrument
         self.size = size if isinstance(size, Decimal) else Decimal(size)

--- a/tensortrade/oms/orders/broker.py
+++ b/tensortrade/oms/orders/broker.py
@@ -80,13 +80,17 @@ class Broker(OrderListener, TimeIndexed):
         Then the broker will find any orders that are active, but expired, and
         proceed to cancel them.
         """
+        executed_ids = []
         for order in self.unexecuted:
             if order.is_executable:
-                self.unexecuted.remove(order)
+                executed_ids.append(order.id)
                 self.executed[order.id] = order
 
                 order.attach(self)
                 order.execute()
+        
+        for order_id in executed_ids:
+            self.unexecuted.remove(self.executed[order_id])
 
         for order in self.unexecuted + list(self.executed.values()):
             if order.is_active and order.is_expired:

--- a/tensortrade/oms/orders/create.py
+++ b/tensortrade/oms/orders/create.py
@@ -303,10 +303,10 @@ def proportion_order(portfolio: 'Portfolio',
 
     pair = portfolio.base_instrument / target.instrument
 
-    order += OrderSpec(
+    order.add_order_spec(OrderSpec(
         side=TradeSide.BUY,
         trade_type=TradeType.MARKET,
         exchange_pair=ExchangePair(exchange, pair),
         criteria=None
-    )
+    ))
     return order


### PR DESCRIPTION
Removing the executed order from the list in the for loop breaks the loop.

```
a = ["a","b","c","d","e"]
for i,l in enumerate(a):
  print(i,l)
  if l=="b":
    a.remove(l)
print(a)
```
```
0 a
1 b
2 d
3 e
['a', 'c', 'd', 'e']
```
