### PR TITLE
feat(docker): mount examples as volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ build-gpu-if-not-built:
 	if [ ! $$(docker images -q ${GPU_IMAGE}) ]; then $(MAKE) build-gpu; fi;
 
 run-notebook: build-cpu-if-not-built
-	docker run -it --rm -p=8888:8888 ${CPU_IMAGE} jupyter notebook --ip='*' --port=8888 --no-browser --allow-root ./examples/
+	docker run -it --rm -p=8888:8888 -v ${PWD}/examples:/examples ${CPU_IMAGE} jupyter notebook --ip='*' --port=8888 --no-browser --allow-root ./examples/
 
 run-docs: build-cpu-if-not-built
 	if [ $$(docker ps -aq --filter name=tensortrade_docs) ]; then docker rm $$(docker ps -aq --filter name=tensortrade_docs); fi;
@@ -49,7 +49,7 @@ run-tests: build-cpu-if-not-built
 	docker run -it --rm ${CPU_IMAGE} make test
 
 run-notebook-gpu: build-gpu-if-not-built
-	docker run -it --rm -p=8888:8888 ${GPU_IMAGE} jupyter notebook --ip='*' --port=8888 --no-browser --allow-root /examples/
+	docker run -it --rm -p=8888:8888 -v ${PWD}/examples:/examples ${GPU_IMAGE} jupyter notebook --ip='*' --port=8888 --no-browser --allow-root /examples/
 
 run-docs-gpu: build-gpu-if-not-built
 	if [ $$(docker ps -aq --filter name=tensortrade_docs) ]; then docker rm $$(docker ps -aq --filter name=tensortrade_docs); fi;


### PR DESCRIPTION
Hi!

I had started tensortrade a few days ago and made some changes in some files. I exited the docker process and restarted it a few days later to find that my changes had not persisted.

This change mounts the examples directory as a volume. As you make changes in Jupyter, they are saved on disk.