### PR TITLE
Update a2c_agent.py

### DIFF
--- a/tensortrade/agents/a2c_agent.py
+++ b/tensortrade/agents/a2c_agent.py
@@ -224,7 +224,7 @@ class A2CAgent(Agent):
 
                 if n_steps and steps_done >= n_steps:
                     done = True
-                    stop_training = True
+                    #stop_training = True
 
             is_checkpoint = save_every and episode % save_every == 0
 


### PR DESCRIPTION
Setting `stop_training` as True results in the termination of training after the completion of the steps of the first episode.