### PR TITLE
fix: fix typo in renderers documentation example

### DIFF
--- a/examples/renderers_and_plotly_chart.ipynb
+++ b/examples/renderers_and_plotly_chart.ipynb
@@ -703,7 +703,7 @@
     "    feed=feed,\n",
     "    window_size=20,\n",
     "    renderer_feed=renderer_feed,\n",
-    "    renderers=[\n",
+    "    renderer=[\n",
     "        chart_renderer, \n",
     "        file_logger\n",
     "    ]\n",


### PR DESCRIPTION
Fix small typo in the documentation. I had to spend some time to figure out the issue, so hope this fix will save time to others.