### PR TITLE
All packages now reference setup.py.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.7.0-gpu
+FROM tensorflow/tensorflow:2.8.0-gpu
 
 ENV NVIDIA_VISIBLE_DEVICES \
     ${NVIDIA_VISIBLE_DEVICES:-all}
@@ -16,8 +16,10 @@ COPY . ./
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get update && \
-    apt-get install -yq --assume-yes --no-install-recommends git \
+    apt-get install -yq --assume-yes --no-install-recommends cmake \
+                                                             git \
                                                              libgl1-mesa-glx \
+                                                             libopenmpi-dev \
                                                              python3-pip \
                                                              python3-dev \
                                                              python3-setuptools \
@@ -32,10 +34,7 @@ RUN apt-get update && \
     make install && \
     cd .. && \
     pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir -r "./examples/requirements.txt" && \
+    pip3 install --no-cache-dir -e ".[optional]" && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* ta-lib-0.4.0-src.tar.gz
-
-# Faster compilation for tests
-RUN pip3 install --no-cache-dir -e ".[docs,tests]"
 

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,13 +1,3 @@
 -r ../requirements.txt
 
-ray[default,tune,rllib,serve]==1.9.2
-ccxt>=1.72.37
-jupyterlab>=1.1.4
-feature_engine
-scikit-learn
-optuna
-quantstats
-ta>=0.4.7
-TA-Lib
-git+https://github.com/twopirllc/pandas-ta@development
-
+.[optional]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,1 @@
-numpy>=1.17.0
-pandas>=0.25.0
-gym>=0.15.7
-pyyaml>=5.1.2
-stochastic>=0.6.0
-tensorflow>=2.7.0
-ipython>=7.12.0
-matplotlib>=3.1.1
-plotly>=4.5.0
-ipywidgets>=7.0.0  # Required for rendering
-deprecated>=1.2.13
+.

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,122 @@ with open(os.path.join(tensortrade_directory, 'tensortrade', 'version.py'), 'r')
         if line.startswith('__version__'):
             version = line[15:-2]
 
+
+install_requires = [
+    'numpy>=1.17.0',
+    'pandas>=0.25.0',
+    'gym>=0.15.7',
+    'pyyaml>=5.1.2',
+    'matplotlib>=3.1.1',
+    'plotly>=4.5.0',
+    'deprecated>=1.2.13'
+]
+
+ray_requires = [
+    'ray[default,tune,rllib,serve]==1.10.0',
+]
+
+stable_baselines_requires = [
+    'stable-baselines3[extra]',
+    'sb3-contrib'
+]
+
+tensorflow_requires = [
+    'tensorflow>=2.8.0'
+]
+
+pytorch_requires = [
+    'torch>=1.10.2'
+]
+
+ta_requires = [
+    'ta>=0.4.7'
+]
+
+indicators_requires = [
+    'quantstats',
+    'TA-Lib',
+    'pandas-ta @ git+https://github.com/twopirllc/pandas-ta.git@development',
+    ta_requires[0]
+]
+
+agents_requires = [
+    'pyarrow',
+    'wandb',
+    'tensorflow-probability>=0.15.0',
+    'opencv-python'
+]
+
+binance_requires = [
+    'python-binance',
+    'binance-futures @ git+https://github.com/Binance-docs/Binance_Futures_python.git#egg=binance-futures'
+]
+
+notebook_requires = [
+    'jupyterlab>=1.1.4',
+    'ipython>=7.12.0',
+    'ipywidgets>=7.0.0'
+]
+
+examples_requires = [
+    'stochastic>=0.6.0',
+    'ccxt==1.72.37',
+    'feature_engine',
+    'scikit-learn',
+    'optuna',
+    notebook_requires[0]
+]
+
+tests_requires = [
+    'pytest>=5.1.1',
+    ta_requires[0]
+]
+
+docs_requires = [
+    'sphinx',
+    'sphinx_rtd_theme',
+    'sphinxcontrib.apidoc',
+    'nbsphinx',
+    'nbsphinx_link',
+    'recommonmark',
+    'sphinx_markdown_tables',
+    'ipykernel'
+]
+
+optional_requires = \
+    ray_requires + \
+    stable_baselines_requires + \
+    tensorflow_requires + \
+    pytorch_requires + \
+    indicators_requires + \
+    agents_requires + \
+    binance_requires + \
+    examples_requires + \
+    tests_requires + \
+    docs_requires
+
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Natural Language :: English',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Education',
+    'Intended Audience :: Science/Research',
+    'Intended Audience :: Financial and Insurance Industry',
+    'Intended Audience :: Information Technology',
+    'License :: OSI Approved :: Apache Software License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Topic :: Office/Business :: Financial :: Investment',
+    'Topic :: Office/Business :: Financial',
+    'Topic :: Scientific/Engineering :: Information Analysis',
+    'Topic :: System :: Distributed Computing',
+    'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    'Topic :: Software Development :: Libraries',
+    'Topic :: Software Development :: Libraries :: Python Modules',
+]
+
 setup(
     name='tensortrade',
     version=version,
@@ -45,54 +161,23 @@ setup(
     ],
     license='Apache 2.0',
     python_requires='>=3.7',
-    install_requires=[
-        'numpy>=1.17.0',
-        'pandas>=0.25.0',
-        'gym>=0.15.7',
-        'pyyaml>=5.1.2',
-        'stochastic>=0.6.0',
-        'tensorflow>=2.7.0',
-        'ipython>=7.12.0',
-        'matplotlib>=3.1.1',
-        'plotly>=4.5.0',
-        'deprecated>=1.2.13'
-    ],
+    install_requires=install_requires,
     extras_require={
-        'tests': [
-            'pytest>=5.1.1',
-            'ta>=0.4.7'
-        ],
-        'docs': [
-            'sphinx',
-            'sphinx_rtd_theme',
-            'sphinxcontrib.apidoc',
-            'nbsphinx',
-            'nbsphinx_link',
-            'recommonmark',
-            'sphinx_markdown_tables',
-            'ipykernel'
-        ],
+        'ray': ray_requires,
+        'stable_baselines': stable_baselines_requires,
+        'tensorflow': tensorflow_requires,
+        'pytorch': pytorch_requires,
+        'agents': agents_requires,
+        'binance': binance_requires,
+        'ta': ta_requires,
+        'indicators': indicators_requires,
+        'notebook': notebook_requires,
+        'examples': examples_requires,
+        'tests': tests_requires,
+        'docs': docs_requires,
+        'optional': optional_requires
     },
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Natural Language :: English',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Financial and Insurance Industry',
-        'Intended Audience :: Information Technology',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Topic :: Office/Business :: Financial :: Investment',
-        'Topic :: Office/Business :: Financial',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: System :: Distributed Computing',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ],
+    classifiers=classifiers,
     zip_safe=False
 )
+


### PR DESCRIPTION
    requirements.txt and examples/requirements.txt now reference setup.py.
    install_requires is now only numpy>=1.17.0, pandas>=0.25.0, gym>=0.15.7, pyyaml>=5.1.2, matplotlib>=3.1.1, plotly>=4.5.0 and deprecated>=1.2.13.
    Upgraded to ray==1.10.0 as a separate extra.
    Added stable-baselines3[extra] and sb3-contrib as a separate extra.
    Upgraded to tensorflow==2.8.0 as a separate extra.
    torch>=1.10.2 is a separate extra.
    indicators_requires now include pandas-ta, TA-Lib, quantstats as well as ta>=0.4.7
    agents_requires (borrowed from xagents, for a later update) require pyarrow, wandb, tensorflow-probability>=0.15.0 and opencv-python, which will be removed when the code is cleansed from it
    support is added for python-binance and binance-futures for a later update
    Jupyter notebook is supported as an extra with jupyterlab>=1.1.4, ipython>=7.12.0 and ipywidgets>=7.0.0
    tests_requires and docs_requires are unchanged.
    optional_requires concatenates all the above options for a one option install of all options.