### PR TITLE
Convert all columns to lower case

### DIFF
--- a/tensortrade/data/cdd.py
+++ b/tensortrade/data/cdd.py
@@ -65,8 +65,9 @@ class CryptoDataDownload:
 
         df = pd.read_csv(self.url + filename, skiprows=1)
         df = df[::-1]
-        df = df.drop(["symbol"], axis=1)
         df = df.rename({base_vc: new_base_vc, quote_vc: new_quote_vc, "Date": "date"}, axis=1)
+        df.columns = df.columns.str.lower()
+        df = df.drop(["symbol"], axis=1)
 
         df["unix"] = df["unix"].astype(int)
         df["unix"] = df["unix"].apply(


### PR DESCRIPTION
To fix parsing Binance data files.

You will get error without this fix when you want to download Binance data.

code to test:

```
ccd.fetch_default('Binance', 'USDT', 'BTC', '1h', False)
```